### PR TITLE
Update README for WSL setup and ignore local CMake build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,7 @@ lib/zephyr-workspace/*
 /.vscode/
 .DS_Store
 *.gcov
+
+# Ignore local CMake build
+cmake-3.27.9*
+

--- a/README.md
+++ b/README.md
@@ -43,11 +43,8 @@ python3 -m venv fprime-venv
 4. Activate the virtual environment
 ```sh
 # In fprime-nucleo_h723zg-zephyr-reference
-# Linux & MacOS
+# Linux, MacOS, & Windows WSL
 source fprime-venv/bin/activate
-
-# Windows
-source fprime-venv/Scripts/activate
 ```
 
 5. With the virtual environment activated, install the requirements

--- a/README.md
+++ b/README.md
@@ -1,12 +1,29 @@
 # fprime-nucleo_h723zg-zephyr-reference F' project
+> [!Note]
+> This deployment targets the NUCLEO-H723ZG development board and has been verified on macOS and on Windows 11 using WSL (Ubuntu 22.04 LTS)
+
+## System Requirements
+
+- F Prime System Requirements listed [here](https://fprime.jpl.nasa.gov/latest/docs/getting-started/installing-fprime/#system-requirements)
+- Zephyr dependencies listed [here](https://docs.zephyrproject.org/latest/develop/getting_started/index.html)
+- Minimum required **CMake version: 3.27.0**
+
+> If your system CMake is older than 3.27, it **must be upgraded**. On WSL, this must be often done manually.
+
+>[!Note]
+> For users using WSL please see important instructions below under section **WSL (Windows 11) Notes**
+
+---
 
 ## Prerequisites
 1. Follow the [Hello World Tutorial](https://fprime.jpl.nasa.gov/latest/tutorials-hello-world/docs/hello-world/)
 2. Follow the [zephyr Getting Started Guide](https://docs.zephyrproject.org/latest/develop/getting_started/index.html) 
 3. Install the stm32 board manager. [This](https://github.com/fprime-community/fprime-arduino/blob/main/docs/arduino-cli-install.md) guide can be used.
 
+---
+
 ## Initial project setup
-The setup.sh script can be run to build and install all required dependencies for this project
+The setup.sh script can be run to build and install all required dependencies for this project and assumes the prerequisites steps have been completed.
 ```sh
 bash setup.sh
 ```
@@ -42,7 +59,7 @@ sh ~/Library/Arduino15/packages/STMicroelectronics/tools/STM32Tools/2.3.0/stm32C
 > `/dev/cu.usbmodem142203` will likely need to be replaced with the correct port. This can be found by running the following command: `ls -l /dev/cu.usb*`
 
 > [!Note]
-> Two USBs connections are required. USB PWR is used to flash the development board and access the debug terminal, USER USB is used to connect to the f prime GDS
+> Two USB connections are required. USB PWR is used to power and flash the development board and access the debug terminal, USER USB is used to connect to the F Prime GDS
 
 ## Running the application and F' GDS
 
@@ -55,3 +72,35 @@ fprime-gds -n --dictionary ./build-artifacts/zephyr/fprime-zephyr-deployment/dic
 
 > [!Note]
 > `/dev/cu.usbmodem142101` will likely need to be replaced with the correct port. This can be found by running the following command: `ls -l /dev/cu.usb*`
+
+## WSL (Windows 11) Notes
+WSL doesn't natively have access to USB devices. To flash the board properly and allow the GDS to communicate with the deployment board via UART over USB, follow these one-time steps
+
+1. On Powershell as administrator, install and run **usbipd-win**: 
+Run Powershell as administrator 
+```
+winget install dorssel.usbipd-win 
+```
+
+2. On Powershell find your USB device:
+```
+usbipd list
+```
+
+3. On Powershell bind the device to USBIPD (as administrator):
+```
+usbipd bind --busid <BUSID>
+```
+
+4. On Powershell attach USB device to WSL:
+```
+usbipd attach --busid <BUSID> --wsl
+```
+
+5. On WSL confirm visibility of USB device:
+```
+ls /dev/ttyACM*
+```
+> [!Note]
+> On WSL, the device will usually appear as /dev/ttyACM0. You can check using ls /dev/ttyACM*
+

--- a/README.md
+++ b/README.md
@@ -13,12 +13,6 @@
 >[!Note]
 > For users using WSL please see important instructions below under section **WSL (Windows 11) Notes**
 
----
-
-## System Requirements
-1. F Prime System Requirements listed [here](https://github.com/nasa/fprime/tree/14bac5f350fef9add6c58592c690ebdabfbc83c7?tab=readme-ov-file#system-requirements)
-2. Zephyr dependencies listed [here](https://docs.zephyrproject.org/latest/develop/getting_started/index.html#install-dependencies)
-
 ## Prerequisites
 1. Follow the [Hello World Tutorial](https://fprime.jpl.nasa.gov/latest/tutorials-hello-world/docs/hello-world/)
 2. Follow the [Zephyr Getting Started Guide](https://docs.zephyrproject.org/latest/develop/getting_started/index.html). Ensure that the Zephyr SDK is installed.
@@ -92,14 +86,11 @@ fprime-util build
 ```sh
 # In fprime-nucleo_h723zg-zephyr-reference
 
-# Linux
+# Linux/Windows WSL
 sh ~/.arduino15/packages/STMicroelectronics/tools/STM32Tools/2.3.0/stm32CubeProg.sh -i swd -f build-fprime-automatic-zephyr/zephyr/zephyr.hex -c /dev/ttyACM0
 
 # MacOS
 sh ~/Library/Arduino15/packages/STMicroelectronics/tools/STM32Tools/2.3.0/stm32CubeProg.sh -i swd -f build-fprime-automatic-zephyr/zephyr/zephyr.hex -c /dev/cu.usbmodem142203 
-
-# Windows
-# TODO
 ```
 
 > [!Note]

--- a/README.md
+++ b/README.md
@@ -86,15 +86,16 @@ winget install dorssel.usbipd-win
 ```
 usbipd list
 ```
+> [!Note]
+> You should see two STM32 devices listed with different BUSID's. One corresponds to the USB PWR and the other to USER USB.
 
-3. On Powershell bind the device to USBIPD (as administrator):
+3. On Powershell bind both devices to USBIPD in two seperate commands (as administrator):
 ```
-usbipd bind --busid <BUSID>
+usbipd bind --busid <BUSID_USB_PWR> --wsl
 ```
 
-4. On Powershell attach USB device to WSL:
 ```
-usbipd attach --busid <BUSID> --wsl
+usbipd bind --busid <BUSID_USER_USB> --wsl
 ```
 
 5. On WSL confirm visibility of USB device:

--- a/README.md
+++ b/README.md
@@ -151,5 +151,3 @@ ls /dev/ttyACM*
 ```
 > [!Note]
 > On WSL, the device will usually appear as /dev/ttyACM0. You can check using ls /dev/ttyACM*
-
-> `/dev/cu.usbmodem142101` will likely need to be replaced with the correct port.


### PR DESCRIPTION
This update adds detailed setup instructions for Windows 11 users running WSL (Ubuntu 22.04 LTS), including USB access steps using usbipd. Also clarified the minimum required CMake version to ensure compatibility with Zephyr and F Prime tooling. 